### PR TITLE
Fix bug preventing inline GraphQL arguments

### DIFF
--- a/dist/link.js
+++ b/dist/link.js
@@ -85,7 +85,7 @@ var neo4jGraphqlQuery = function neo4jGraphqlQuery(driver, observer, operation, 
   if (logRequests === true) {
     console.log('neo4jGraphqlQuery sending request\n' + request + ' with variables\n', operation.variables);
   }
-  session.run('CALL graphql.query("' + request + '", {' + transformVariables(operation.variables) + '})', operation.variables).then(function (result) {
+  session.run('CALL graphql.query(\'' + request + '\', {' + transformVariables(operation.variables) + '})', operation.variables).then(function (result) {
     session.close();
     observer.next({
       data: result.records[0]._fields[0]
@@ -101,7 +101,7 @@ var neo4jGraphqlExecute = function neo4jGraphqlExecute(driver, observer, operati
   if (logRequests === true) {
     console.log('neo4jGraphqlQuery sending request:\n' + request + ' with variables:\n', operation.variables);
   }
-  session.run('CALL graphql.execute("' + request + '", {' + transformVariables(operation.variables) + '})', operation.variables).then(function (result) {
+  session.run('CALL graphql.execute(\'' + request + '\', {' + transformVariables(operation.variables) + '})', operation.variables).then(function (result) {
     session.close();
     observer.next({
       data: result.records[0]._fields[0]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0"
+    "babel-plugin-transform-async-generator-functions": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1"
   }
 }

--- a/src/link.js
+++ b/src/link.js
@@ -74,7 +74,7 @@ const neo4jGraphqlQuery = (driver, observer, operation, logRequests) => {
   if(logRequests === true) {
     console.log(`neo4jGraphqlQuery sending request\n${request} with variables\n`, operation.variables);
   }
-  session.run(`CALL graphql.query("${request}", {${transformVariables(operation.variables)}})`, operation.variables)
+  session.run(`CALL graphql.query('${request}', {${transformVariables(operation.variables)}})`, operation.variables)
   .then(result => {
     session.close();
     observer.next({
@@ -92,7 +92,7 @@ const neo4jGraphqlExecute = (driver, observer, operation, logRequests) => {
   if(logRequests === true) {
     console.log(`neo4jGraphqlQuery sending request:\n${request} with variables:\n`, operation.variables);
   }
-  session.run(`CALL graphql.execute("${request}", {${transformVariables(operation.variables)}})`, operation.variables)
+  session.run(`CALL graphql.execute('${request}', {${transformVariables(operation.variables)}})`, operation.variables)
   .then(result => {
     session.close();
     observer.next({


### PR DESCRIPTION
The use of double quotes inside the template literal ended up being transpiled by babel into code that messed up when inline arguments were used in GraphQL (which use double quotes as well).